### PR TITLE
Fix root URLs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -150,7 +150,7 @@ impl Client {
         let addr = self.url.host_str().ok_or(Error::Url(UrlError::Address))?;
         let path = self.url.path();
 
-        let mut url = [scheme, "://", addr, path, "/rest/"].concat();
+        let mut url = [scheme, "://", addr, path, "rest/"].concat();
         url.push_str(query);
         url.push('?');
         url.push_str(&self.auth.to_url(self.target_ver));


### PR DESCRIPTION
When `ping()`ing my Navidrome, the constructed URL has two slashes:

```
Connecting to https://<omitted>.com//rest/ping
```

which causes an error. This PR prevents this issue.