### PR TITLE
Convert IDs to `String`

### DIFF
--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -72,12 +72,12 @@ impl Annotatable for Artist {
 
 impl Annotatable for Album {
     fn star(&self, client: &Client) -> Result<()> {
-        client.get("star", Query::with("albumId", self.id))?;
+        client.get("star", Query::with("albumId", self.id.clone()))?;
         Ok(())
     }
 
     fn unstar(&self, client: &Client) -> Result<()> {
-        client.get("unstar", Query::with("albumId", self.id))?;
+        client.get("unstar", Query::with("albumId", self.id.clone()))?;
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl Annotatable for Album {
             return Err(Error::Other("rating must be between 0 and 5 inclusive"));
         }
 
-        let args = Query::with("id", self.id).arg("rating", rating).build();
+        let args = Query::with("id", self.id.clone()).arg("rating", rating).build();
         client.get("setRating", args)?;
         Ok(())
     }
@@ -96,7 +96,7 @@ impl Annotatable for Album {
         B: Into<Option<bool>>,
         T: Into<Option<&'a str>>,
     {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("time", time.into())
             .arg("submission", now_playing.into().map(|b| !b))
             .build();
@@ -107,12 +107,12 @@ impl Annotatable for Album {
 
 impl Annotatable for Song {
     fn star(&self, client: &Client) -> Result<()> {
-        client.get("star", Query::with("id", self.id))?;
+        client.get("star", Query::with("id", self.id.clone()))?;
         Ok(())
     }
 
     fn unstar(&self, client: &Client) -> Result<()> {
-        client.get("unstar", Query::with("id", self.id))?;
+        client.get("unstar", Query::with("id", self.id.clone()))?;
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl Annotatable for Song {
             return Err(Error::Other("rating must be between 0 and 5 inclusive"));
         }
 
-        let args = Query::with("id", self.id).arg("rating", rating).build();
+        let args = Query::with("id", self.id.clone()).arg("rating", rating).build();
         client.get("setRating", args)?;
         Ok(())
     }
@@ -131,7 +131,7 @@ impl Annotatable for Song {
         B: Into<Option<bool>>,
         T: Into<Option<&'a str>>,
     {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("time", time.into())
             .arg("submission", now_playing.into().map(|b| !b))
             .build();

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -37,12 +37,12 @@ pub trait Annotatable {
 
 impl Annotatable for Artist {
     fn star(&self, client: &Client) -> Result<()> {
-        client.get("star", Query::with("artistId", self.id))?;
+        client.get("star", Query::with("artistId", self.id.clone()))?;
         Ok(())
     }
 
     fn unstar(&self, client: &Client) -> Result<()> {
-        client.get("unstar", Query::with("artistId", self.id))?;
+        client.get("unstar", Query::with("artistId", self.id.clone()))?;
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl Annotatable for Artist {
             return Err(Error::Other("rating must be between 0 and 5 inclusive"));
         }
 
-        let args = Query::with("id", self.id).arg("rating", rating).build();
+        let args = Query::with("id", self.id.clone()).arg("rating", rating).build();
         client.get("setRating", args)?;
         Ok(())
     }
@@ -61,7 +61,7 @@ impl Annotatable for Artist {
         B: Into<Option<bool>>,
         T: Into<Option<&'a str>>,
     {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("time", time.into())
             .arg("submission", now_playing.into().map(|b| !b))
             .build();

--- a/src/client.rs
+++ b/src/client.rs
@@ -388,7 +388,7 @@ pub struct License {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util;
+    use crate::{id::Id, test_util};
 
     #[test]
     fn test_token_auth() {
@@ -433,14 +433,14 @@ mod tests {
         let s = SearchPage::new().with_size(1);
         let r = cli.search("dada", s, s, s).unwrap();
 
-        assert_eq!(r.artists[0].id, 14);
+        assert_eq!(r.artists[0].id, Id::from(14));
         assert_eq!(r.artists[0].name, String::from("The Dada Weatherman"));
         assert_eq!(r.artists[0].album_count, 4);
 
-        assert_eq!(r.albums[0].id, "23");
+        assert_eq!(r.albums[0].id, Id::from(23));
         assert_eq!(r.albums[0].name, String::from("The Green Waltz"));
 
-        assert_eq!(r.songs[0].id, "222");
+        assert_eq!(r.songs[0].id, Id::from(222));
 
         // etc.
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -437,10 +437,10 @@ mod tests {
         assert_eq!(r.artists[0].name, String::from("The Dada Weatherman"));
         assert_eq!(r.artists[0].album_count, 4);
 
-        assert_eq!(r.albums[0].id, 23);
+        assert_eq!(r.albums[0].id, "23");
         assert_eq!(r.albums[0].name, String::from("The Green Waltz"));
 
-        assert_eq!(r.songs[0].id, 222);
+        assert_eq!(r.songs[0].id, "222");
 
         // etc.
     }

--- a/src/collections/album.rs
+++ b/src/collections/album.rs
@@ -55,7 +55,7 @@ impl IntoArg for ListType {
 #[derive(Debug, Clone)]
 #[readonly::make]
 pub struct Album {
-    pub id: u64,
+    pub id: String,
     pub name: String,
     pub artist: Option<String>,
     pub artist_id: Option<u64>,
@@ -74,8 +74,8 @@ impl Album {
     ///
     /// Aside from errors the `Client` may cause, the method will error if
     /// there is no album matching the provided ID.
-    pub fn get(client: &Client, id: usize) -> Result<Album> {
-        self::get_album(client, id as u64)
+    pub fn get(client: &Client, id: String) -> Result<Album> {
+        self::get_album(client, id)
     }
 
     /// Lists all albums on the server. Supports paging.
@@ -91,7 +91,7 @@ impl Album {
     /// Returns all songs in the album.
     pub fn songs(&self, client: &Client) -> Result<Vec<Song>> {
         if self.songs.len() as u64 != self.song_count {
-            Ok(self::get_album(client, self.id)?.songs)
+            Ok(self::get_album(client, self.id.clone())?.songs)
         } else {
             Ok(self.songs.clone())
         }
@@ -99,7 +99,7 @@ impl Album {
 
     /// Returns detailed information about the album.
     pub fn info(&self, client: &Client) -> Result<AlbumInfo> {
-        let res = client.get("getArtistInfo", Query::with("id", self.id))?;
+        let res = client.get("getArtistInfo", Query::with("id", self.id.clone()))?;
         Ok(serde_json::from_value(res)?)
     }
 }
@@ -225,7 +225,7 @@ impl<'de> Deserialize<'de> for AlbumInfo {
     }
 }
 
-fn get_album(client: &Client, id: u64) -> Result<Album> {
+fn get_album(client: &Client, id: String) -> Result<Album> {
     let res = client.get("getAlbum", Query::with("id", id))?;
     Ok(serde_json::from_value::<Album>(res)?)
 }
@@ -268,7 +268,7 @@ mod tests {
     fn parse_album() {
         let parsed = serde_json::from_value::<Album>(raw()).unwrap();
 
-        assert_eq!(parsed.id, 1);
+        assert_eq!(parsed.id, "1");
         assert_eq!(parsed.name, String::from("Bellevue"));
         assert_eq!(parsed.song_count, 9);
     }
@@ -277,7 +277,7 @@ mod tests {
     fn parse_album_deep() {
         let parsed = serde_json::from_value::<Album>(raw()).unwrap();
 
-        assert_eq!(parsed.songs[0].id, 27);
+        assert_eq!(parsed.songs[0].id, "27");
         assert_eq!(parsed.songs[0].title, String::from("Bellevue Avenue"));
         assert_eq!(parsed.songs[0].duration, Some(198));
     }

--- a/src/collections/album.rs
+++ b/src/collections/album.rs
@@ -58,7 +58,7 @@ pub struct Album {
     pub id: String,
     pub name: String,
     pub artist: Option<String>,
-    pub artist_id: Option<u64>,
+    pub artist_id: Option<String>,
     pub cover_id: Option<String>,
     pub duration: u64,
     pub year: Option<u64>,

--- a/src/collections/artist.rs
+++ b/src/collections/artist.rs
@@ -209,7 +209,7 @@ mod tests {
         let parsed = serde_json::from_value::<Artist>(raw()).unwrap();
 
         assert_eq!(parsed.albums.len(), parsed.album_count);
-        assert_eq!(parsed.albums[0].id, 1);
+        assert_eq!(parsed.albums[0].id, "1");
         assert_eq!(parsed.albums[0].name, String::from("Bellevue"));
         assert_eq!(parsed.albums[0].song_count, 9);
     }
@@ -220,7 +220,7 @@ mod tests {
         let parsed = serde_json::from_value::<Artist>(raw()).unwrap();
         let albums = parsed.albums(&srv).unwrap();
 
-        assert_eq!(albums[0].id, 1);
+        assert_eq!(albums[0].id, "1");
         assert_eq!(albums[0].name, String::from("Bellevue"));
         assert_eq!(albums[0].song_count, 9);
     }

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -4,6 +4,8 @@ use std::result;
 
 use serde::de::{Deserialize, Deserializer};
 
+use crate::id::Id;
+
 pub mod album;
 pub mod artist;
 pub mod playlist;
@@ -16,7 +18,7 @@ pub use self::playlist::Playlist;
 #[derive(Debug)]
 pub struct MusicFolder {
     /// The index number of the folder.
-    pub id: usize,
+    pub id: Id,
     /// The name assigned to the folder.
     pub name: String,
     _private: bool,

--- a/src/collections/playlist.rs
+++ b/src/collections/playlist.rs
@@ -12,7 +12,7 @@ use crate::{Client, Error, Media, Result, Song};
 #[derive(Debug)]
 #[readonly::make]
 pub struct Playlist {
-    pub id: u64,
+    pub id: String,
     pub name: String,
     pub duration: u64,
     pub cover_id: String,
@@ -24,7 +24,7 @@ impl Playlist {
     /// Fetches the songs contained in a playlist.
     pub fn songs(&self, client: &Client) -> Result<Vec<Song>> {
         if self.songs.len() as u64 != self.song_count {
-            Ok(get_playlist(client, self.id)?.songs)
+            Ok(get_playlist(client, self.id.clone())?.songs)
         } else {
             Ok(self.songs.clone())
         }
@@ -97,7 +97,7 @@ pub fn get_playlists(client: &Client, user: Option<String>) -> Result<Vec<Playli
 }
 
 #[allow(missing_docs)]
-pub fn get_playlist(client: &Client, id: u64) -> Result<Playlist> {
+pub fn get_playlist(client: &Client, id: String) -> Result<Playlist> {
     let res = client.get("getPlaylist", Query::with("id", id))?;
     Ok(serde_json::from_value::<Playlist>(res)?)
 }
@@ -125,7 +125,7 @@ pub fn create_playlist(client: &Client, name: String, songs: &[u64]) -> Result<O
 /// Updates a playlist. Only the owner of the playlist is privileged to do so.
 pub fn update_playlist<'a, B, S>(
     client: &Client,
-    id: u64,
+    id: String,
     name: S,
     comment: S,
     public: B,
@@ -150,7 +150,7 @@ where
 }
 
 #[allow(missing_docs)]
-pub fn delete_playlist(client: &Client, id: u64) -> Result<()> {
+pub fn delete_playlist(client: &Client, id: String) -> Result<()> {
     client.get("deletePlaylist", Query::with("id", id))?;
     Ok(())
 }

--- a/src/collections/playlist.rs
+++ b/src/collections/playlist.rs
@@ -5,6 +5,7 @@ use std::result;
 use serde::de::{Deserialize, Deserializer};
 use serde_json;
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::{Client, Error, Media, Result, Song};
 
@@ -12,7 +13,7 @@ use crate::{Client, Error, Media, Result, Song};
 #[derive(Debug)]
 #[readonly::make]
 pub struct Playlist {
-    pub id: String,
+    pub id: Id,
     pub name: String,
     pub duration: u64,
     pub cover_id: String,
@@ -97,8 +98,8 @@ pub fn get_playlists(client: &Client, user: Option<String>) -> Result<Vec<Playli
 }
 
 #[allow(missing_docs)]
-pub fn get_playlist(client: &Client, id: String) -> Result<Playlist> {
-    let res = client.get("getPlaylist", Query::with("id", id))?;
+pub fn get_playlist<I: Into<Id>>(client: &Client, id: I) -> Result<Playlist> {
+    let res = client.get("getPlaylist", Query::with("id", id.into()))?;
     Ok(serde_json::from_value::<Playlist>(res)?)
 }
 
@@ -106,10 +107,11 @@ pub fn get_playlist(client: &Client, id: String) -> Result<Playlist> {
 ///
 /// Since API version 1.14.0, the newly created playlist is returned. In earlier
 /// versions, an empty response is returned.
-pub fn create_playlist(client: &Client, name: String, songs: &[u64]) -> Result<Option<Playlist>> {
+pub fn create_playlist<I: Into<Id> + Clone>(client: &Client, name: String, songs: &[I]) -> Result<Option<Playlist>> {
+    let song_ids: Vec<Id> = songs.iter().cloned().map(|id| id.into()).collect();
     let args = Query::new()
         .arg("name", name)
-        .arg_list("songId", songs)
+        .arg_list("songId", &song_ids)
         .build();
 
     let res = client.get("createPlaylist", args)?;
@@ -123,25 +125,28 @@ pub fn create_playlist(client: &Client, name: String, songs: &[u64]) -> Result<O
 }
 
 /// Updates a playlist. Only the owner of the playlist is privileged to do so.
-pub fn update_playlist<'a, B, S>(
+pub fn update_playlist<'a, B, S, I, T>(
     client: &Client,
-    id: String,
+    id: I,
     name: S,
     comment: S,
     public: B,
-    to_add: &[u64],
+    to_add: &[T],
     to_remove: &[u64],
 ) -> Result<()>
 where
+    I: Into<Id>,
     S: Into<Option<&'a str>>,
     B: Into<Option<bool>>,
+    T: Into<Id> + Clone,
 {
+    let song_ids_to_add: Vec<Id> = to_add.iter().cloned().map(|id| id.into()).collect();
     let args = Query::new()
-        .arg("id", id)
+        .arg("id", id.into())
         .arg("name", name.into())
         .arg("comment", comment.into())
         .arg("public", public.into())
-        .arg_list("songIdToAdd", to_add)
+        .arg_list("songIdToAdd", &song_ids_to_add)
         .arg_list("songIndexToRemove", to_remove)
         .build();
 
@@ -150,8 +155,8 @@ where
 }
 
 #[allow(missing_docs)]
-pub fn delete_playlist(client: &Client, id: String) -> Result<()> {
-    client.get("deletePlaylist", Query::with("id", id))?;
+pub fn delete_playlist<I: Into<Id>>(client: &Client, id: I) -> Result<()> {
+    client.get("deletePlaylist", Query::with("id", id.into()))?;
     Ok(())
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,58 @@
+//! ID intermediate type for compatibility between servers that have different ID formats.
+use crate::query::{Arg, IntoArg};
+
+/// ID type used by various Subsonic entities.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum Id {
+    /// Numeric ID type.
+    Numeric(usize),
+    /// String ID type.
+    String(String),
+}
+
+impl IntoArg for Id {
+    fn into_arg(self) -> Arg {
+        match self {
+            Id::Numeric(n) => n.into_arg(),
+            Id::String(s) => s.into_arg(),
+        }
+    }
+}
+
+impl std::str::FromStr for Id {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // It's not worth trying to distinguish between numeric and string IDs here.
+        // Play it safe, if the user wants a numeric ID they can explicitly convert it.
+        Ok(Id::String(s.to_string()))
+    }
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Id::Numeric(n) => write!(f, "{}", n),
+            Id::String(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<usize> for Id {
+    fn from(id: usize) -> Self {
+        Id::Numeric(id)
+    }
+}
+
+impl From<String> for Id {
+    fn from(id: String) -> Self {
+        Id::String(id)
+    }
+}
+
+impl From<&str> for Id {
+    fn from(id: &str) -> Self {
+        Id::String(id.to_string())
+    }
+}

--- a/src/jukebox.rs
+++ b/src/jukebox.rs
@@ -76,7 +76,7 @@ impl<'a> Jukebox<'a> {
         Jukebox { client }
     }
 
-    fn send_action_with<U>(&self, action: &str, index: U, ids: &[usize]) -> Result<JukeboxStatus>
+    fn send_action_with<U>(&self, action: &str, index: U, ids: &[String]) -> Result<JukeboxStatus>
     where
         U: Into<Option<usize>>,
     {
@@ -128,7 +128,7 @@ impl<'a> Jukebox<'a> {
 
     /// Adds the song to the jukebox's playlist.
     pub fn add(&self, song: &Song) -> Result<JukeboxStatus> {
-        self.send_action_with("add", None, &[song.id as usize])
+        self.send_action_with("add", None, &[song.id.clone()])
     }
 
     /// Adds a song matching the provided ID to the playlist.
@@ -137,8 +137,8 @@ impl<'a> Jukebox<'a> {
     ///
     /// The method will return an error if a song matching the provided ID
     /// cannot be found.
-    pub fn add_id(&self, id: usize) -> Result<JukeboxStatus> {
-        self.send_action_with("add", None, &[id])
+    pub fn add_id(&self, id: String) -> Result<JukeboxStatus> {
+        self.send_action_with("add", None, &[id.clone()])
     }
 
     /// Adds all the songs to the jukebox's playlist.
@@ -146,7 +146,7 @@ impl<'a> Jukebox<'a> {
         self.send_action_with(
             "add",
             None,
-            &songs.iter().map(|s| s.id as usize).collect::<Vec<_>>(),
+            &songs.iter().map(|s| s.id.clone()).collect::<Vec<_>>(),
         )
     }
 
@@ -156,7 +156,7 @@ impl<'a> Jukebox<'a> {
     ///
     /// The method will return an error if at least one ID cannot be matched to
     /// a song.
-    pub fn add_all_ids(&self, ids: &[usize]) -> Result<JukeboxStatus> {
+    pub fn add_all_ids(&self, ids: &[String]) -> Result<JukeboxStatus> {
         self.send_action_with("add", None, ids)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ mod error;
 
 pub mod annotate;
 pub mod collections;
+pub mod id;
 pub mod jukebox;
 pub mod media;
 pub mod query;

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -139,7 +139,7 @@ pub struct NowPlaying {
     pub minutes_ago: usize,
     /// The ID of the player.
     pub player_id: usize,
-    id: usize,
+    id: String,
     is_video: bool,
 }
 
@@ -156,7 +156,7 @@ impl NowPlaying {
         if self.is_video {
             Err(Error::Other("Now Playing info is not a song"))
         } else {
-            Song::get(client, self.id as u64)
+            Song::get(client, self.id.clone())
         }
     }
 
@@ -172,7 +172,7 @@ impl NowPlaying {
         if !self.is_video {
             Err(Error::Other("Now Playing info is not a video"))
         } else {
-            Video::get(client, self.id)
+            Video::get(client, self.id.clone())
         }
     }
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use serde::de::{Deserialize, Deserializer};
 
+use crate::id::Id;
 use crate::{Client, Error, Result};
 
 pub mod format;
@@ -139,7 +140,7 @@ pub struct NowPlaying {
     pub minutes_ago: usize,
     /// The ID of the player.
     pub player_id: usize,
-    id: String,
+    id: Id,
     is_video: bool,
 }
 

--- a/src/media/podcast.rs
+++ b/src/media/podcast.rs
@@ -4,6 +4,7 @@ use std::result;
 
 use serde::de::{Deserialize, Deserializer};
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::{Client, Result};
 
@@ -11,7 +12,7 @@ use crate::{Client, Result};
 #[derive(Debug)]
 #[readonly::make]
 pub struct Podcast {
-    pub id: usize,
+    pub id: Id,
     pub url: String,
     pub title: String,
     pub description: String,
@@ -26,8 +27,8 @@ pub struct Podcast {
 #[derive(Debug)]
 #[readonly::make]
 pub struct Episode {
-    pub id: usize,
-    pub parent: usize,
+    pub id: Id,
+    pub parent: Id,
     pub is_dir: bool,
     pub title: String,
     pub album: String,
@@ -41,7 +42,7 @@ pub struct Episode {
     pub bitrate: usize,
     pub is_video: bool,
     pub created: String,
-    pub artist_id: String,
+    pub artist_id: Id,
     pub media_type: String,
     pub stream_id: String,
     pub channel_id: String,
@@ -54,7 +55,7 @@ impl Podcast {
     /// Fetches the details of a single podcast and its episodes.
     pub fn get<U>(client: &Client, id: U) -> Result<Podcast>
     where
-        U: Into<Option<usize>>,
+        U: Into<Option<Id>>,
     {
         let channel = client.get("getPodcasts", Query::with("id", id.into()))?;
         Ok(get_list_as!(channel, Podcast).remove(0))
@@ -178,7 +179,7 @@ impl<'de> Deserialize<'de> for Episode {
             bitrate: raw.bit_rate,
             is_video: raw.is_video,
             created: raw.created,
-            artist_id: raw.artist_id,
+            artist_id: raw.artist_id.parse().unwrap(),
             media_type: raw._type,
             stream_id: raw.stream_id,
             channel_id: raw.channel_id,

--- a/src/media/radio.rs
+++ b/src/media/radio.rs
@@ -4,6 +4,7 @@ use std::result;
 
 use serde::de::{Deserialize, Deserializer};
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::{Client, Result};
 
@@ -11,7 +12,7 @@ use crate::{Client, Result};
 #[derive(Debug)]
 #[readonly::make]
 pub struct RadioStation {
-    pub id: usize,
+    pub id: Id,
     pub name: String,
     pub stream_url: String,
     pub homepage_url: Option<String>,
@@ -42,8 +43,8 @@ impl<'de> Deserialize<'de> for RadioStation {
 
 #[allow(missing_docs)]
 impl RadioStation {
-    pub fn id(&self) -> usize {
-        self.id
+    pub fn id(&self) -> Id {
+        self.id.clone()
     }
 
     pub fn list(client: &Client) -> Result<Vec<RadioStation>> {
@@ -62,7 +63,7 @@ impl RadioStation {
     }
 
     pub fn update(&self, client: &Client) -> Result<()> {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("streamUrl", self.stream_url.as_str())
             .arg("name", self.name.as_str())
             .arg("homepageUrl", self.homepage_url.as_deref())
@@ -72,7 +73,7 @@ impl RadioStation {
     }
 
     pub fn delete(&self, client: &Client) -> Result<()> {
-        client.get("deleteInternetRadioStation", Query::with("id", self.id))?;
+        client.get("deleteInternetRadioStation", Query::with("id", self.id.clone()))?;
         Ok(())
     }
 }

--- a/src/media/song.rs
+++ b/src/media/song.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use serde::de::{Deserialize, Deserializer};
 use serde_json;
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::search::SearchPage;
 use crate::{Client, Error, HlsPlaylist, Media, Result, Streamable};
@@ -15,18 +16,18 @@ use crate::{Client, Error, HlsPlaylist, Media, Result, Streamable};
 #[readonly::make]
 pub struct Song {
     /// Unique identifier for the song.
-    pub id: String,
+    pub id: Id,
     /// Title of the song. Prefers the song's ID3 tags, but will fall back to
     /// the file name.
     pub title: String,
     /// Album the song belongs to. Reads from the song's ID3 tags.
     pub album: Option<String>,
     /// The ID of the released album.
-    pub album_id: Option<String>,
+    pub album_id: Option<Id>,
     /// Credited artist for the song. Reads from the song's ID3 tags.
     pub artist: Option<String>,
     /// The ID of the releasing artist.
-    pub artist_id: Option<String>,
+    pub artist_id: Option<Id>,
     /// Position of the song in the album.
     pub track: Option<u64>,
     /// Year the song was released.
@@ -64,8 +65,8 @@ impl Song {
     ///
     /// Aside from other errors the `Client` may cause, the server will return
     /// an error if there is no song matching the provided ID.
-    pub fn get(client: &Client, id: String) -> Result<Song> {
-        let res = client.get("getSong", Query::with("id", id))?;
+    pub fn get<I: Into<Id>>(client: &Client, id: I) -> Result<Song> {
+        let res = client.get("getSong", Query::with("id", id.into()))?;
         Ok(serde_json::from_value(res)?)
     }
 
@@ -364,7 +365,7 @@ pub struct RandomSongs<'a> {
     genre: Option<&'a str>,
     from_year: Option<usize>,
     to_year: Option<usize>,
-    folder_id: Option<usize>,
+    folder_id: Option<Id>,
 }
 
 impl<'a> RandomSongs<'a> {
@@ -426,8 +427,8 @@ impl<'a> RandomSongs<'a> {
     /// folders can be found using the [`Client::music_folders`] method.
     ///
     /// [`Client::music_folders`]: ../struct.Client.html#method.music_folders
-    pub fn in_folder(&mut self, id: usize) -> &mut RandomSongs<'a> {
-        self.folder_id = Some(id);
+    pub fn in_folder<I: Into<Id>>(&mut self, id: I) -> &mut RandomSongs<'a> {
+        self.folder_id = Some(id.into());
         self
     }
 
@@ -438,7 +439,7 @@ impl<'a> RandomSongs<'a> {
             .arg("genre", self.genre)
             .arg("fromYear", self.from_year)
             .arg("toYear", self.to_year)
-            .arg("musicFolderId", self.folder_id)
+            .arg("musicFolderId", self.folder_id.clone())
             .build();
 
         let song = self.client.get("getRandomSongs", args)?;
@@ -455,7 +456,7 @@ mod tests {
     fn parse_song() {
         let parsed = serde_json::from_value::<Song>(raw()).unwrap();
 
-        assert_eq!(parsed.id, "27");
+        assert_eq!(parsed.id, Id::from(27));
         assert_eq!(parsed.title, String::from("Bellevue Avenue"));
         assert_eq!(parsed.track, Some(1));
     }

--- a/src/media/video.rs
+++ b/src/media/video.rs
@@ -12,7 +12,7 @@ use crate::{Client, Error, Media, Result, Streamable};
 #[derive(Debug)]
 #[readonly::make]
 pub struct Video {
-    pub id: usize,
+    pub id: String,
     pub parent: usize,
     pub is_dir: bool,
     pub title: String,
@@ -41,7 +41,7 @@ pub struct Video {
 
 impl Video {
     #[allow(missing_docs)]
-    pub fn get(client: &Client, id: usize) -> Result<Video> {
+    pub fn get(client: &Client, id: String) -> Result<Video> {
         Video::list(client)?
             .into_iter()
             .find(|v| v.id == id)
@@ -59,7 +59,7 @@ impl Video {
     where
         S: Into<Option<&'a str>>,
     {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("format", format.into())
             .build();
         let res = client.get("getVideoInfo", args)?;
@@ -71,7 +71,7 @@ impl Video {
     where
         S: Into<Option<&'a str>>,
     {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("format", format.into())
             .build();
         let res = client.get_raw("getCaptions", args)?;
@@ -95,7 +95,7 @@ impl Video {
 
 impl Streamable for Video {
     fn stream(&self, client: &Client) -> Result<Vec<u8>> {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("maxBitRate", self.stream_br)
             .arg(
                 "size",
@@ -107,7 +107,7 @@ impl Streamable for Video {
     }
 
     fn stream_url(&self, client: &Client) -> Result<String> {
-        let args = Query::with("id", self.id)
+        let args = Query::with("id", self.id.clone())
             .arg("maxBitRate", self.stream_br)
             .arg(
                 "size",
@@ -119,11 +119,11 @@ impl Streamable for Video {
     }
 
     fn download(&self, client: &Client) -> Result<Vec<u8>> {
-        client.get_bytes("download", Query::with("id", self.id))
+        client.get_bytes("download", Query::with("id", self.id.clone()))
     }
 
     fn download_url(&self, client: &Client) -> Result<String> {
-        client.build_url("download", Query::with("id", self.id))
+        client.build_url("download", Query::with("id", self.id.clone()))
     }
 
     fn encoding(&self) -> &str {
@@ -350,7 +350,7 @@ mod tests {
     fn parse_video() {
         let parsed = serde_json::from_value::<Video>(raw()).unwrap();
 
-        assert_eq!(parsed.id, 460);
+        assert_eq!(parsed.id, "460");
         assert_eq!(parsed.title, "Big Buck Bunny");
         assert!(!parsed.has_cover_art());
     }

--- a/src/media/video.rs
+++ b/src/media/video.rs
@@ -5,6 +5,7 @@ use std::result;
 use serde::de::{Deserialize, Deserializer};
 use serde_json;
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::{Client, Error, Media, Result, Streamable};
 
@@ -12,8 +13,8 @@ use crate::{Client, Error, Media, Result, Streamable};
 #[derive(Debug)]
 #[readonly::make]
 pub struct Video {
-    pub id: String,
-    pub parent: usize,
+    pub id: Id,
+    pub parent: Id,
     pub is_dir: bool,
     pub title: String,
     pub album: Option<String>,
@@ -41,7 +42,9 @@ pub struct Video {
 
 impl Video {
     #[allow(missing_docs)]
-    pub fn get(client: &Client, id: String) -> Result<Video> {
+    pub fn get(client: &Client, id: impl Into<Id>) -> Result<Video> {
+        let id = id.into();
+
         Video::list(client)?
             .into_iter()
             .find(|v| v.id == id)
@@ -350,7 +353,7 @@ mod tests {
     fn parse_video() {
         let parsed = serde_json::from_value::<Video>(raw()).unwrap();
 
-        assert_eq!(parsed.id, "460");
+        assert_eq!(parsed.id, Id::from(460));
         assert_eq!(parsed.title, "Big Buck Bunny");
         assert!(!parsed.has_cover_art());
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -2,6 +2,7 @@
 
 use serde_json;
 
+use crate::id::Id;
 use crate::query::Query;
 use crate::{Client, Result};
 
@@ -69,7 +70,7 @@ pub struct User {
     pub avatar_last_changed: String,
     /// The list of media folders the user has access to.
     #[serde(rename = "folder")]
-    pub folders: Vec<u64>,
+    pub folders: Vec<Id>,
     #[serde(default)]
     _private: bool,
 }
@@ -173,7 +174,7 @@ impl User {
             .arg("podcastRole", self.podcast_role)
             .arg("shareRole", self.share_role)
             .arg("videoConversionRole", self.video_conversion_role)
-            .arg_list("musicFolderId", &self.folders.clone())
+            .arg_list("musicFolderId", &self.folders)
             .arg("maxBitRate", self.max_bit_rate)
             .build();
         client.get("updateUser", args)?;
@@ -199,7 +200,7 @@ pub struct UserBuilder {
     podcast_role: bool,
     share_role: bool,
     video_conversion_role: bool,
-    folders: Vec<u64>,
+    folders: Vec<Id>,
     max_bit_rate: u64,
 }
 
@@ -255,7 +256,7 @@ impl UserBuilder {
     // Allows the user to start video coversions.
     build!(video_conversion_role: bool);
     // IDs of the music folders the user is allowed to access.
-    build!(folders: &[u64]);
+    build!(folders: &[Id]);
     // The maximum bit rate (in Kbps) the user is allowed to stream at. Higher
     // bit rate streams will be downsampled to their limit.
     build!(max_bit_rate: u64);


### PR DESCRIPTION
Fixes #7 and #10 

Converts all IDs to `String` in order to fix Navidrome compatibility.
