### PR TITLE
Add `Read` stream

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -150,7 +150,7 @@ impl Client {
         let addr = self.url.host_str().ok_or(Error::Url(UrlError::Address))?;
         let path = self.url.path();
 
-        let mut url = [scheme, "://", addr, path, "/rest/"].concat();
+        let mut url = [scheme, "://", addr, path, "rest/"].concat();
         url.push_str(query);
         url.push('?');
         url.push_str(&self.auth.to_url(self.target_ver));
@@ -210,6 +210,12 @@ impl Client {
         let uri: Url = self.build_url(query, args)?.parse().unwrap();
         let res = self.reqclient.get(uri).send()?;
         Ok(res.bytes().map(|b| b.unwrap()).collect())
+    }
+
+    /// Returns a streaming response.
+    pub(crate) fn get_stream(&self, query: &str, args: Query) -> Result<reqwest::Response> {
+        let uri: Url = self.build_url(query, args)?.parse().unwrap();
+        Ok(self.reqclient.get(uri).send()?)
     }
 
     /// Returns the raw bytes of a HLS slice.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 //! let random_songs = Song::random(&client, 20)?;
 //! for mut song in random_songs {
 //!     song.set_max_bit_rate(320);
-//!     let bytes = song.stream(&client)?;
-//!     // Use another library to stream the `bytes`!
+//!     let mut reader = song.stream(&client)?;
+//!     // Use the reader to stream the audio data
 //! }
 //! # Ok(())
 //! # }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,5 +1,6 @@
 //! Individual media APIs.
 
+use std::io::Read;
 use std::ops::Index;
 use std::result;
 use std::str::FromStr;
@@ -23,15 +24,16 @@ use self::video::Video;
 
 /// A trait for forms of streamable media.
 pub trait Streamable {
-    /// Returns the raw bytes of the media.
+    /// Returns a reader for the media.
     ///
     /// Supports transcoding options specified on the media beforehand. See the
     /// struct-level documentation for available options. The `Media` trait
     /// provides setting a maximum bit rate and a target transcoding format.
     ///
-    /// The method does not provide any information about the encoding of the
-    /// media without evaluating the stream itself.
-    fn stream(&self, client: &Client) -> Result<Vec<u8>>;
+    /// The method returns a reader that implements `Read`, allowing
+    /// for efficient streaming without loading the entire media into memory
+    /// at once.
+    fn stream(&self, client: &Client) -> Result<Box<dyn Read>>;
 
     /// Returns a constructed URL for streaming.
     ///

--- a/src/media/song.rs
+++ b/src/media/song.rs
@@ -1,6 +1,7 @@
 //! Song APIs.
 
 use std::fmt;
+use std::io::Read;
 use std::ops::Range;
 
 use serde::de::{Deserialize, Deserializer};
@@ -162,10 +163,11 @@ impl Song {
 }
 
 impl Streamable for Song {
-    fn stream(&self, client: &Client) -> Result<Vec<u8>> {
+    fn stream(&self, client: &Client) -> Result<Box<dyn Read>> {
         let mut q = Query::with("id", self.id);
         q.arg("maxBitRate", self.stream_br);
-        client.get_bytes("stream", q)
+        let response = client.get_stream("stream", q)?;
+        Ok(Box::new(response))
     }
 
     fn stream_url(&self, client: &Client) -> Result<String> {

--- a/src/media/video.rs
+++ b/src/media/video.rs
@@ -1,5 +1,6 @@
 //! Video APIs.
 
+use std::io::Read;
 use std::result;
 
 use serde::de::{Deserialize, Deserializer};
@@ -94,7 +95,7 @@ impl Video {
 }
 
 impl Streamable for Video {
-    fn stream(&self, client: &Client) -> Result<Vec<u8>> {
+    fn stream(&self, client: &Client) -> Result<Box<dyn Read>> {
         let args = Query::with("id", self.id)
             .arg("maxBitRate", self.stream_br)
             .arg(
@@ -103,7 +104,8 @@ impl Streamable for Video {
             )
             .arg("timeOffset", self.stream_offset)
             .build();
-        client.get_bytes("stream", args)
+        let response = client.get_stream("stream", args)?;
+        Ok(Box::new(response))
     }
 
     fn stream_url(&self, client: &Client) -> Result<String> {


### PR DESCRIPTION
Makes the `stream()` method of `Streamable` return something that implements `Read` rather than loading the entire thing at once.

Example:

```rust
use sunk::{Client, Streamable, song::Song};

extern crate sunk;

pub fn main() {
  let username = "guest3";
  let password = "guest";
  let site = "http://demo.subsonic.org";

  let client = Client::new(site, username, password).unwrap();

  // Update the library.
  client.ping().unwrap();
  client.scan_library().unwrap();

  // Fetch some songs and play them.
  let song = Song::get(&client, "some-id").unwrap();
  let mut stream = song.stream(&client).unwrap();

  // Read into 512 byte buffer and log bytes read
  let mut buffer = [0u8; 512];

  loop {
      let bytes_read = stream.read(&mut buffer).unwrap();

      if bytes_read == 0 {
          break;
      }

      println!("Read {} bytes", bytes_read);
  }
}
```